### PR TITLE
Taking into account quoted text

### DIFF
--- a/plugin/content_scripts/compose.js
+++ b/plugin/content_scripts/compose.js
@@ -1,9 +1,10 @@
-browser.runtime.onMessage.addListener((message) => {
+(function () {
 
-  const insertNode = (range, text) => {
+  const makeParagraphs = (text, func) => {
+    console.log('ins', text);
     const chunks = text.split(/\n{2,}/);
     if (chunks.length == 1) {
-      return range.insertNode(document.createTextNode(text));
+      return func(document.createTextNode(text));
     }
     const paragraphs = chunks.map((t) => {
       const p = document.createElement("p");
@@ -11,19 +12,49 @@ browser.runtime.onMessage.addListener((message) => {
       return p;
     });
     for (let i = paragraphs.length - 1; i >= 0; i--) {
-      range.insertNode(paragraphs[i]);
+      func(paragraphs[i]);
     }
   };
 
-  if (message.command === "getSelectedText") {
-    return Promise.resolve(window.getSelection().toString());
-  } else if (message.command === "replaceSelectedText") {
-    const sel = window.getSelection();
-    if (!sel || sel.type !== "Range" || !sel.rangeCount) {
-      return;
+  const insert = function (text) {
+    const prefix = window.document.body.getElementsByClassName("moz-cite-prefix");
+    if (prefix.length >= 0) {
+      console.log("found prefix");
+      const divider = prefix[0];
+      let sibling = divider.previousSibling;
+      while (sibling) {
+        window.document.body.removeChild(sibling);
+        sibling = sibling.sibling;
+      }
+      console.log('after removal', window.document.body.innerHTML);
     }
-    const r = sel.getRangeAt(0);
-    r.deleteContents();
-    insertNode(r, message.text);
+    return makeParagraphs(text, function (p) {
+      window.document.body.insertBefore(p, window.document.body.firstChild);
+    });
   }
-});
+
+  browser.runtime.onMessage.addListener((message) => {
+
+    if (message.command === "getSelectedText") {
+      return Promise.resolve(window.getSelection().toString());
+    } else if (message.command === "replaceSelectedText") {
+      console.log('replacing with', message.text);
+      const selectedText = window.getSelection().toString();
+      console.log('current selection', selectedText);
+      if (!selectedText) {
+        return insert(message.text);
+      }
+      const sel = window.getSelection();
+      if (!sel || sel.type !== "Range" || !sel.rangeCount) {
+        return;
+      }
+      const r = sel.getRangeAt(0);
+      r.deleteContents();
+      makeParagraphs(message.text, function (p) {
+        r.insertNode(p);
+      });
+    } else if (message.command === "getText") {
+      return Promise.resolve(window.document.body.textContent);
+    }
+  });
+})();

--- a/plugin/content_scripts/compose.js
+++ b/plugin/content_scripts/compose.js
@@ -1,7 +1,6 @@
 (function () {
 
   const makeParagraphs = (text, func) => {
-    console.log('ins', text);
     const chunks = text.split(/\n{2,}/);
     if (chunks.length == 1) {
       return func(document.createTextNode(text));
@@ -16,17 +15,16 @@
     }
   };
 
+ 
   const insert = function (text) {
     const prefix = window.document.body.getElementsByClassName("moz-cite-prefix");
     if (prefix.length >= 0) {
-      console.log("found prefix");
       const divider = prefix[0];
       let sibling = divider.previousSibling;
       while (sibling) {
         window.document.body.removeChild(sibling);
-        sibling = sibling.sibling;
+        sibling = divider.previousSibling;
       }
-      console.log('after removal', window.document.body.innerHTML);
     }
     return makeParagraphs(text, function (p) {
       window.document.body.insertBefore(p, window.document.body.firstChild);
@@ -38,9 +36,7 @@
     if (message.command === "getSelectedText") {
       return Promise.resolve(window.getSelection().toString());
     } else if (message.command === "replaceSelectedText") {
-      console.log('replacing with', message.text);
       const selectedText = window.getSelection().toString();
-      console.log('current selection', selectedText);
       if (!selectedText) {
         return insert(message.text);
       }
@@ -54,7 +50,17 @@
         r.insertNode(p);
       });
     } else if (message.command === "getText") {
-      return Promise.resolve(window.document.body.textContent);
+      let t = '';
+      const children = window.document.body.childNodes;
+      for (const node of children) {
+        if (node instanceof Element) {
+          if (node.classList.contains('moz-signature')) {
+            continue;
+          }
+        }
+        t += node.textContent;
+      }
+      return Promise.resolve(t);
     }
   });
 })();

--- a/plugin/content_scripts/compose.js
+++ b/plugin/content_scripts/compose.js
@@ -18,7 +18,7 @@
  
   const insert = function (text) {
     const prefix = window.document.body.getElementsByClassName("moz-cite-prefix");
-    if (prefix.length >= 0) {
+    if (prefix.length > 0) {
       const divider = prefix[0];
       let sibling = divider.previousSibling;
       while (sibling) {

--- a/plugin/html/actions.js
+++ b/plugin/html/actions.js
@@ -9,19 +9,24 @@ const addAction = (name, prompt, actionsContainer) => {
 
     const getHighlight = async () => {
         const tabs = await browser.tabs.query({ active: true, currentWindow: true });
-        return {tabId: tabs[0].id, text: await browser.tabs.sendMessage(tabs[0].id, { command: "getSelectedText" })};
+        return {tabId: tabs[0].id, 
+            selection: await browser.tabs.sendMessage(tabs[0].id, { command: "getSelectedText" }),
+            text: await browser.tabs.sendMessage(tabs[0].id, { command: "getText" })
+        };
     };
 
     nameInput.onclick = async () => {
         const hl = await getHighlight();
-        if (hl.text) {
-            const messages = [{role: "system", content: prompt},
-                    {role: "user", content: hl.text}];
-            browser.storage.local.set({ messages, draftTitle: name, tabId: hl.tabId }).then( () => {
-                browser.windows.create({ url: "/html/draft.html", type: "popup",
-                            width: 600, height: 512 });
-            });
+        const messages = [{role: "system", content: prompt}];
+        if (hl.selection) {
+            messages.push({role: "user", content: hl.selection});
+        } else {
+            messages.push({role: "user", content: hl.text});
         }
+        browser.storage.local.set({ messages, draftTitle: name, tabId: hl.tabId }).then( () => {
+            browser.windows.create({ url: "/html/draft.html", type: "popup",
+                        width: 600, height: 512 });
+        });
     };
     actionDiv.appendChild(nameInput);
     actionsContainer.appendChild(actionDiv);

--- a/plugin/html/actions.js
+++ b/plugin/html/actions.js
@@ -1,5 +1,17 @@
 import { promptVersion } from './globals.js';
 
+const truncate = async (text) => {
+    const { maxSize } = await browser.storage.local.get(
+        ["maxSize"]);
+    const max = parseInt(maxSize, 10);
+    if (isNaN(max) || max <= 0) {
+        return text;
+    }
+    const ret = text.substring(0, Math.min(text.length, max));
+    return ret;
+}
+    
+
 const addAction = (name, prompt, actionsContainer) => {
     const actionDiv = document.createElement("div");
     const nameInput = document.createElement("p");
@@ -19,9 +31,9 @@ const addAction = (name, prompt, actionsContainer) => {
         const hl = await getHighlight();
         const messages = [{role: "system", content: prompt}];
         if (hl.selection) {
-            messages.push({role: "user", content: hl.selection});
+            messages.push({role: "user", content: await truncate(hl.selection)});
         } else {
-            messages.push({role: "user", content: hl.text});
+            messages.push({role: "user", content: await truncate(hl.text)});
         }
         browser.storage.local.set({ messages, draftTitle: name, tabId: hl.tabId }).then( () => {
             browser.windows.create({ url: "/html/draft.html", type: "popup",

--- a/plugin/html/settings.html
+++ b/plugin/html/settings.html
@@ -63,6 +63,11 @@
 	</div>
       </div>
       <div class="row">
+        <div class="col-25"> <label for="max-size">Max Input (in chars)</label></div>
+        <div class="col-75"> <input type="text" id="max-size" placeholder="Send up to N characters.." class="full-width"></div>
+      </div>
+      </div>
+      <div class="row">
 	<div class="col-25"></div>
 	<div class="col-75">
 	  <button id="get-models" value="Update Model List" class="button neutral">Update Models (need API key)</button>

--- a/plugin/html/settings.js
+++ b/plugin/html/settings.js
@@ -60,7 +60,7 @@ const handleWarning = (promptUpdated, notesContainer) => {
     }
 };
 
-const saveSettings = (actionsContainer, modelSelect, apiKeyInput, maxTokensInput) => {
+const saveSettings = (actionsContainer, modelSelect, apiKeyInput, maxTokensInput, maxSizeInput) => {
     const actions = Array.from(actionsContainer.children).map(actionDiv => {
         const nameInput = actionDiv.querySelector(".action-name");
         const promptInput = actionDiv.querySelector(".action-prompt");
@@ -72,17 +72,19 @@ const saveSettings = (actionsContainer, modelSelect, apiKeyInput, maxTokensInput
         apiKey: apiKeyInput.value,
         actions: actions,
         maxTokens: maxTokensInput.value,
+        maxSize: maxSizeInput.value,
         promptUpdated: promptVersion
     });
 };
 
-const setDefaultSettings = (actionsContainer, modelSelect, apiKeyInput, maxTokensInput) => {
+const setDefaultSettings = (actionsContainer, modelSelect, apiKeyInput, maxTokensInput, maxSizeInput) => {
     while (actionsContainer.firstChild) {
         actionsContainer.firstChild.remove();
     }
     modelSelect.value = defaultModel;
     apiKeyInput.value = "";
     maxTokensInput.value = 0;
+    maxSizeInput.value = 0;
     defaultActions.forEach(({ name, prompt }) => {
         addAction(name, prompt, actionsContainer);
     });
@@ -125,22 +127,24 @@ document.addEventListener("DOMContentLoaded", () => {
     const saveButton = document.getElementById("save-settings");
     const getModelsButton = document.getElementById("get-models");
     const maxTokensInput = document.getElementById("max-tokens");
+    const maxSizeInput = document.getElementById("max-size");
     const defaultButton = document.getElementById("default-settings");
     const notesContainer = document.getElementById("notes-container");
 
-    browser.storage.local.get(["model", "apiKey", "actions", "maxTokens", "promptUpdated"], (data) => {
-        const { model = defaultModel, apiKey = '', maxTokens = 0, promptUpdated = 0, actions = defaultActions } = data;
+    browser.storage.local.get(["model", "apiKey", "actions", "maxTokens", "promptUpdated", "maxSize"], (data) => {
+        const { model = defaultModel, apiKey = '', maxTokens = 0, promptUpdated = 0, maxSize = 0, actions = defaultActions } = data;
 
         apiKeyInput.value = apiKey;
         addModelToSelect(model, modelSelect);
         maxTokensInput.value = maxTokens;
+        maxSizeInput.value = maxSize;
         handleWarning(promptUpdated, notesContainer);
 
         actions.forEach(({ name, prompt }) => addAction(name, prompt, actionsContainer));
 
         addActionButton.addEventListener("click", () => addAction("", "", actionsContainer));
-        saveButton.addEventListener("click", () => saveSettings(actionsContainer, modelSelect, apiKeyInput, maxTokensInput));
-        defaultButton.addEventListener("click", () => setDefaultSettings(actionsContainer, modelSelect, apiKeyInput, maxTokensInput));
+        saveButton.addEventListener("click", () => saveSettings(actionsContainer, modelSelect, apiKeyInput, maxTokensInput, maxSizeInput));
+        defaultButton.addEventListener("click", () => setDefaultSettings(actionsContainer, modelSelect, apiKeyInput, maxTokensInput, maxSizeInput));
         getModelsButton.addEventListener("click", () => getModels(apiKeyInput.value));
     });
 });


### PR DESCRIPTION
When replying on email and no text is selected, sending the whole content (including the quoted text) to ChatGPT to provide additional context. When inserting ChatGPT response back in this scenario, removing all the content before quoted text and replacing it with the ChatGPT response, so user reply is replaced with the ChatGPT response but the original quoted message(s) remain unchanged. If extension was unable to determine beginning of the quoted message(s), then ChatGPT response is inserted at the beginning. No changes in extension's behavior when part of text is selected. 

Also, added new optional configuration parameter that allows to limit number of characters being sent to ChatGPT, to avoid model limits overflow.